### PR TITLE
Add Dockerfile symlink to root dir to enable Docker Hub Automatic Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+Library/docker/Dockerfile


### PR DESCRIPTION
This simply adds a symlink to the projects root dir to enable Automatic Builds off the container on Docker Hub. The Dockerfile in Library/docker contains pathes relative to the root dir. Docker Hub can't build this way, as it sets the PWD to the directory of the Dockerfile (see: https://hub.docker.com/r/m3adow/dockertk/)
